### PR TITLE
Changes bundler version to 2.0.2 to comply with heroku

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
           command: |
             echo 'export BUNDLER_VERSION=$(cat Gemfile.lock | tail -1 | tr -d " ")' >> $BASH_ENV
             source $BASH_ENV
-            gem install bundler -v '2.0.1'
+            gem install bundler -v '2.0.2'
 
       - run:
           name: install dependencies

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -179,4 +179,4 @@ RUBY VERSION
    ruby 2.4.1p111
 
 BUNDLED WITH
-   2.0.1
+   2.0.2


### PR DESCRIPTION
- [ ] Check this if the PR has been approved by the team to be a quick patch and the rest of this form will not be filled out

## What functionality does this accomplish?
closes #

**Description:**
In order to deploy to heroku, the bundler version cannot be specified, and in our case will run on bundler `2.0.2`

I am hoping that once this is merged, our deployment to heroku passes. This change did not affect Circle CI, as this build passed.
```
ERROR:

Could not detect rake tasks
 !     ensure you can run `$ bundle exec rake -P` against your app
 !     and using the production group of your Gemfile.
 !     Activating bundler (2.0.1) failed:
 !     Could not find 'bundler' (= 2.0.1) - did find: [bundler-2.0.2]
 !     Checked in 'GEM_PATH=vendor/bundle/ruby/2.4.0', execute `gem env` for more information
 !     
 !     To install the version of bundler this project requires, run `gem install bundler -v '2.0.1'`
```
```
DOCS:

The following libraries are used by the platform for managing and running Ruby applications and cannot be specified. For application dependency resolution and management, bundler is installed based on the contents of your Gemfile.lock. If you have a BUNDLED WITH in your Gemfile.lock then you will receive a different version of Bundler:

Applications specifying Bundler 2.x in their Gemfile.lock will receive bundler: 2.0.2
Applications specifying Bundler 1.x in their Gemfile.lock will receive bundler: 1.15.2
Applications with no BUNDLED WITH in their Gemfile.lock will default to bundler: 1.15.2
```

## Helpful Resources:
* Resource link AND small description of info gathered/learned
[Ruby Bundler Versioning - Heroku](https://devcenter.heroku.com/articles/ruby-support#libraries)

## Review Requests(optional):

## Please include an emoji of how you feel about this branch:
