### PR TITLE
Creates LocationsFacade Spec and VCR Cassette

### DIFF
--- a/app/facades/locations_facade.rb
+++ b/app/facades/locations_facade.rb
@@ -46,11 +46,11 @@ class LocationsFacade
     end
 
     def minutes(index)
-      (proximity_json[:rows][0][:elements][index][:duration][:text]).to_f
+      proximity_json[:rows][0][:elements][index][:duration][:text].to_f
     end
 
     def seconds(index)
-      (proximity_json[:rows][0][:elements][index][:duration][:value]).to_f
+      proximity_json[:rows][0][:elements][index][:duration][:value].to_f
     end
 
     def proximity_json

--- a/spec/facades/locations_facade_spec.rb
+++ b/spec/facades/locations_facade_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+describe 'LocationsFacade' do
+  describe 'instance methods' do
+    context '#combined_data' do
+      it 'returns model data combined with api call data for each location' do
+        VCR.use_cassette('facades/locations_facade_cassette') do
+          loc_1 = create(:location, id: 1, lat: 41.0003 , lng: -107.0003)
+          loc_2 = create(:location, id: 2, lat: 39.5001, lng: -105.0001)
+          loc_3 = create(:location, id: 3, lat: 40.0002, lng: -106.0002)
+
+          params = {lat: "39.7504", lng: "-104.9963"}
+
+          combined_data = LocationsFacade.new(params).combined_data
+
+          expect(combined_data.count).to eq(3)
+          expect(combined_data.first.keys.count).to eq(14)
+
+          expect(combined_data.first.has_key?(:miles)).to eq(true)
+          expect(combined_data.first.has_key?(:meters)).to eq(true)
+          expect(combined_data.first.has_key?(:minutes)).to eq(true)
+          expect(combined_data.first.has_key?(:seconds)).to eq(true)
+        end
+      end
+    end
+
+    context '#sorted' do
+      it 'returns hash of combined location data sorted by closest proximity' do
+        VCR.use_cassette('facades/locations_facade_cassette') do
+          farthest = create(:location, id: 1, lat: 41.0003 , lng: -107.0003)
+          closest = create(:location, id: 2, lat: 39.5001, lng: -105.0001)
+          middle = create(:location, id: 3, lat: 40.0002, lng: -106.0002)
+
+          params = {lat: "39.7504", lng: "-104.9963"}
+
+          sorted = LocationsFacade.new(params).sorted
+
+          expect(sorted.class).to eq(Hash)
+          expect(sorted[:locations].count).to eq(3)
+
+          expect(sorted[:locations].first[:id]).to eq(closest.id)
+          expect(sorted[:locations].first[:miles]).to eq(19.9)
+
+          expect(sorted[:locations].second[:id]).to eq(middle.id)
+          expect(sorted[:locations].second[:miles]).to eq(85.4)
+
+          expect(sorted[:locations].third[:id]).to eq(farthest.id)
+          expect(sorted[:locations].third[:miles]).to eq(202.0)
+        end
+      end
+    end
+  end
+end

--- a/spec/service/google_distance_service_spec.rb
+++ b/spec/service/google_distance_service_spec.rb
@@ -2,23 +2,25 @@ require 'rails_helper'
 
 describe 'GoogleDistanceService' do
   describe 'instance methods' do
-    it 'returns an array of location information' do
-      VCR.use_cassette('services/google_distance_cassette') do
-        create(:location, lat: 39.7807 , lng: -105.0828)
-        create(:location, lat: 39.5982, lng: -105.0218)
-        create(:location, lat: 40.033, lng: -105.2338)
+    context '#get_json' do
+      it 'returns an array of location information' do
+        VCR.use_cassette('services/google_distance_cassette') do
+          create(:location, lat: 39.7807 , lng: -105.0828)
+          create(:location, lat: 39.5982, lng: -105.0218)
+          create(:location, lat: 40.033, lng: -105.2338)
 
-        lat = 39.7504
-        lng = -104.9963
-        destinations_cords = Location.all_cords_formatted
+          lat = 39.7504
+          lng = -104.9963
+          destinations_cords = Location.all_cords_formatted
 
-        response = GoogleDistanceService.new(lat, lng, destinations_cords).get_json
+          response = GoogleDistanceService.new(lat, lng, destinations_cords).get_json
 
-        locations = response[:rows][0][:elements]
+          locations = response[:rows][0][:elements]
 
-        expect(locations.count).to eq(3)
-        expect(locations.first.has_key?(:distance)).to eq(true)
-        expect(locations.first.has_key?(:duration)).to eq(true)
+          expect(locations.count).to eq(3)
+          expect(locations.first.has_key?(:distance)).to eq(true)
+          expect(locations.first.has_key?(:duration)).to eq(true)
+        end
       end
     end
   end

--- a/spec/vcr_cassettes/facades/locations_facade_cassette.yml
+++ b/spec/vcr_cassettes/facades/locations_facade_cassette.yml
@@ -1,0 +1,1119 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://maps.googleapis.com/maps/api/distancematrix/json?destinations=41.0003,-107.0003%7C39.5001,-105.0001%7C40.0002,-106.0002&key=<GOOGLE_DISTANCE_API_KEY>&mode=driving&origins=39.7504,-104.9963&units=imperial
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Sat, 20 Jul 2019 22:43:06 GMT
+      Expires:
+      - Sat, 20 Jul 2019 22:48:06 GMT
+      Cache-Control:
+      - public, max-age=300
+      Vary:
+      - Accept-Language
+      Server:
+      - mafe
+      Content-Length:
+      - '336'
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      Server-Timing:
+      - gfet4t7; dur=210
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="46,43,39"
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+           "destination_addresses" : [
+              "Clark, CO 80428, USA",
+              "9744 Chatridge Ct, Littleton, CO 80125, USA",
+              "Grand Lake, CO 80447, USA"
+           ],
+           "origin_addresses" : [ "1777 Larimer St, Denver, CO 80202, USA" ],
+           "rows" : [
+              {
+                 "elements" : [
+                    {
+                       "distance" : {
+                          "text" : "202 mi",
+                          "value" : 325497
+                       },
+                       "duration" : {
+                          "text" : "4 hours 17 mins",
+                          "value" : 15439
+                       },
+                       "status" : "OK"
+                    },
+                    {
+                       "distance" : {
+                          "text" : "19.9 mi",
+                          "value" : 32029
+                       },
+                       "duration" : {
+                          "text" : "34 mins",
+                          "value" : 2013
+                       },
+                       "status" : "OK"
+                    },
+                    {
+                       "distance" : {
+                          "text" : "85.4 mi",
+                          "value" : 137513
+                       },
+                       "duration" : {
+                          "text" : "1 hour 50 mins",
+                          "value" : 6608
+                       },
+                       "status" : "OK"
+                    }
+                 ]
+              }
+           ],
+           "status" : "OK"
+        }
+    http_version: 
+  recorded_at: Sat, 20 Jul 2019 22:43:02 GMT
+- request:
+    method: get
+    uri: https://maps.googleapis.com/maps/api/distancematrix/json?destinations=41.0003,-107.0003%7C39.5001,-105.0001%7C40.0002,-106.0002&key=<GOOGLE_DISTANCE_API_KEY>&mode=driving&origins=39.7504,-104.9963&units=imperial
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Sat, 20 Jul 2019 22:43:06 GMT
+      Expires:
+      - Sat, 20 Jul 2019 22:48:06 GMT
+      Cache-Control:
+      - public, max-age=300
+      Vary:
+      - Accept-Language
+      Server:
+      - mafe
+      Content-Length:
+      - '336'
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      Server-Timing:
+      - gfet4t7; dur=79
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="46,43,39"
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+           "destination_addresses" : [
+              "Clark, CO 80428, USA",
+              "9744 Chatridge Ct, Littleton, CO 80125, USA",
+              "Grand Lake, CO 80447, USA"
+           ],
+           "origin_addresses" : [ "1777 Larimer St, Denver, CO 80202, USA" ],
+           "rows" : [
+              {
+                 "elements" : [
+                    {
+                       "distance" : {
+                          "text" : "202 mi",
+                          "value" : 325497
+                       },
+                       "duration" : {
+                          "text" : "4 hours 17 mins",
+                          "value" : 15439
+                       },
+                       "status" : "OK"
+                    },
+                    {
+                       "distance" : {
+                          "text" : "19.9 mi",
+                          "value" : 32029
+                       },
+                       "duration" : {
+                          "text" : "34 mins",
+                          "value" : 2013
+                       },
+                       "status" : "OK"
+                    },
+                    {
+                       "distance" : {
+                          "text" : "85.4 mi",
+                          "value" : 137513
+                       },
+                       "duration" : {
+                          "text" : "1 hour 50 mins",
+                          "value" : 6608
+                       },
+                       "status" : "OK"
+                    }
+                 ]
+              }
+           ],
+           "status" : "OK"
+        }
+    http_version: 
+  recorded_at: Sat, 20 Jul 2019 22:43:02 GMT
+- request:
+    method: get
+    uri: https://maps.googleapis.com/maps/api/distancematrix/json?destinations=41.0003,-107.0003%7C39.5001,-105.0001%7C40.0002,-106.0002&key=<GOOGLE_DISTANCE_API_KEY>&mode=driving&origins=39.7504,-104.9963&units=imperial
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Sat, 20 Jul 2019 22:43:07 GMT
+      Expires:
+      - Sat, 20 Jul 2019 22:48:07 GMT
+      Cache-Control:
+      - public, max-age=300
+      Vary:
+      - Accept-Language
+      Server:
+      - mafe
+      Content-Length:
+      - '336'
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      Server-Timing:
+      - gfet4t7; dur=71
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="46,43,39"
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+           "destination_addresses" : [
+              "Clark, CO 80428, USA",
+              "9744 Chatridge Ct, Littleton, CO 80125, USA",
+              "Grand Lake, CO 80447, USA"
+           ],
+           "origin_addresses" : [ "1777 Larimer St, Denver, CO 80202, USA" ],
+           "rows" : [
+              {
+                 "elements" : [
+                    {
+                       "distance" : {
+                          "text" : "202 mi",
+                          "value" : 325497
+                       },
+                       "duration" : {
+                          "text" : "4 hours 17 mins",
+                          "value" : 15439
+                       },
+                       "status" : "OK"
+                    },
+                    {
+                       "distance" : {
+                          "text" : "19.9 mi",
+                          "value" : 32029
+                       },
+                       "duration" : {
+                          "text" : "34 mins",
+                          "value" : 2013
+                       },
+                       "status" : "OK"
+                    },
+                    {
+                       "distance" : {
+                          "text" : "85.4 mi",
+                          "value" : 137513
+                       },
+                       "duration" : {
+                          "text" : "1 hour 50 mins",
+                          "value" : 6608
+                       },
+                       "status" : "OK"
+                    }
+                 ]
+              }
+           ],
+           "status" : "OK"
+        }
+    http_version: 
+  recorded_at: Sat, 20 Jul 2019 22:43:02 GMT
+- request:
+    method: get
+    uri: https://maps.googleapis.com/maps/api/distancematrix/json?destinations=41.0003,-107.0003%7C39.5001,-105.0001%7C40.0002,-106.0002&key=<GOOGLE_DISTANCE_API_KEY>&mode=driving&origins=39.7504,-104.9963&units=imperial
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Sat, 20 Jul 2019 22:43:07 GMT
+      Expires:
+      - Sat, 20 Jul 2019 22:48:07 GMT
+      Cache-Control:
+      - public, max-age=300
+      Vary:
+      - Accept-Language
+      Server:
+      - mafe
+      Content-Length:
+      - '336'
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      Server-Timing:
+      - gfet4t7; dur=77
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="46,43,39"
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+           "destination_addresses" : [
+              "Clark, CO 80428, USA",
+              "9744 Chatridge Ct, Littleton, CO 80125, USA",
+              "Grand Lake, CO 80447, USA"
+           ],
+           "origin_addresses" : [ "1777 Larimer St, Denver, CO 80202, USA" ],
+           "rows" : [
+              {
+                 "elements" : [
+                    {
+                       "distance" : {
+                          "text" : "202 mi",
+                          "value" : 325497
+                       },
+                       "duration" : {
+                          "text" : "4 hours 17 mins",
+                          "value" : 15439
+                       },
+                       "status" : "OK"
+                    },
+                    {
+                       "distance" : {
+                          "text" : "19.9 mi",
+                          "value" : 32029
+                       },
+                       "duration" : {
+                          "text" : "34 mins",
+                          "value" : 2013
+                       },
+                       "status" : "OK"
+                    },
+                    {
+                       "distance" : {
+                          "text" : "85.4 mi",
+                          "value" : 137513
+                       },
+                       "duration" : {
+                          "text" : "1 hour 50 mins",
+                          "value" : 6608
+                       },
+                       "status" : "OK"
+                    }
+                 ]
+              }
+           ],
+           "status" : "OK"
+        }
+    http_version: 
+  recorded_at: Sat, 20 Jul 2019 22:43:03 GMT
+- request:
+    method: get
+    uri: https://maps.googleapis.com/maps/api/distancematrix/json?destinations=41.0003,-107.0003%7C39.5001,-105.0001%7C40.0002,-106.0002&key=<GOOGLE_DISTANCE_API_KEY>&mode=driving&origins=39.7504,-104.9963&units=imperial
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Sat, 20 Jul 2019 22:43:07 GMT
+      Expires:
+      - Sat, 20 Jul 2019 22:48:07 GMT
+      Cache-Control:
+      - public, max-age=300
+      Vary:
+      - Accept-Language
+      Server:
+      - mafe
+      Content-Length:
+      - '336'
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      Server-Timing:
+      - gfet4t7; dur=59
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="46,43,39"
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+           "destination_addresses" : [
+              "Clark, CO 80428, USA",
+              "9744 Chatridge Ct, Littleton, CO 80125, USA",
+              "Grand Lake, CO 80447, USA"
+           ],
+           "origin_addresses" : [ "1777 Larimer St, Denver, CO 80202, USA" ],
+           "rows" : [
+              {
+                 "elements" : [
+                    {
+                       "distance" : {
+                          "text" : "202 mi",
+                          "value" : 325497
+                       },
+                       "duration" : {
+                          "text" : "4 hours 17 mins",
+                          "value" : 15439
+                       },
+                       "status" : "OK"
+                    },
+                    {
+                       "distance" : {
+                          "text" : "19.9 mi",
+                          "value" : 32029
+                       },
+                       "duration" : {
+                          "text" : "34 mins",
+                          "value" : 2013
+                       },
+                       "status" : "OK"
+                    },
+                    {
+                       "distance" : {
+                          "text" : "85.4 mi",
+                          "value" : 137513
+                       },
+                       "duration" : {
+                          "text" : "1 hour 50 mins",
+                          "value" : 6608
+                       },
+                       "status" : "OK"
+                    }
+                 ]
+              }
+           ],
+           "status" : "OK"
+        }
+    http_version: 
+  recorded_at: Sat, 20 Jul 2019 22:43:03 GMT
+- request:
+    method: get
+    uri: https://maps.googleapis.com/maps/api/distancematrix/json?destinations=41.0003,-107.0003%7C39.5001,-105.0001%7C40.0002,-106.0002&key=<GOOGLE_DISTANCE_API_KEY>&mode=driving&origins=39.7504,-104.9963&units=imperial
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Sat, 20 Jul 2019 22:43:07 GMT
+      Expires:
+      - Sat, 20 Jul 2019 22:48:07 GMT
+      Cache-Control:
+      - public, max-age=300
+      Vary:
+      - Accept-Language
+      Server:
+      - mafe
+      Content-Length:
+      - '336'
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      Server-Timing:
+      - gfet4t7; dur=59
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="46,43,39"
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+           "destination_addresses" : [
+              "Clark, CO 80428, USA",
+              "9744 Chatridge Ct, Littleton, CO 80125, USA",
+              "Grand Lake, CO 80447, USA"
+           ],
+           "origin_addresses" : [ "1777 Larimer St, Denver, CO 80202, USA" ],
+           "rows" : [
+              {
+                 "elements" : [
+                    {
+                       "distance" : {
+                          "text" : "202 mi",
+                          "value" : 325497
+                       },
+                       "duration" : {
+                          "text" : "4 hours 17 mins",
+                          "value" : 15439
+                       },
+                       "status" : "OK"
+                    },
+                    {
+                       "distance" : {
+                          "text" : "19.9 mi",
+                          "value" : 32029
+                       },
+                       "duration" : {
+                          "text" : "34 mins",
+                          "value" : 2013
+                       },
+                       "status" : "OK"
+                    },
+                    {
+                       "distance" : {
+                          "text" : "85.4 mi",
+                          "value" : 137513
+                       },
+                       "duration" : {
+                          "text" : "1 hour 50 mins",
+                          "value" : 6608
+                       },
+                       "status" : "OK"
+                    }
+                 ]
+              }
+           ],
+           "status" : "OK"
+        }
+    http_version: 
+  recorded_at: Sat, 20 Jul 2019 22:43:03 GMT
+- request:
+    method: get
+    uri: https://maps.googleapis.com/maps/api/distancematrix/json?destinations=41.0003,-107.0003%7C39.5001,-105.0001%7C40.0002,-106.0002&key=<GOOGLE_DISTANCE_API_KEY>&mode=driving&origins=39.7504,-104.9963&units=imperial
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Sat, 20 Jul 2019 22:43:07 GMT
+      Expires:
+      - Sat, 20 Jul 2019 22:48:07 GMT
+      Cache-Control:
+      - public, max-age=300
+      Vary:
+      - Accept-Language
+      Server:
+      - mafe
+      Content-Length:
+      - '336'
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      Server-Timing:
+      - gfet4t7; dur=162
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="46,43,39"
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+           "destination_addresses" : [
+              "Clark, CO 80428, USA",
+              "9744 Chatridge Ct, Littleton, CO 80125, USA",
+              "Grand Lake, CO 80447, USA"
+           ],
+           "origin_addresses" : [ "1777 Larimer St, Denver, CO 80202, USA" ],
+           "rows" : [
+              {
+                 "elements" : [
+                    {
+                       "distance" : {
+                          "text" : "202 mi",
+                          "value" : 325497
+                       },
+                       "duration" : {
+                          "text" : "4 hours 17 mins",
+                          "value" : 15439
+                       },
+                       "status" : "OK"
+                    },
+                    {
+                       "distance" : {
+                          "text" : "19.9 mi",
+                          "value" : 32029
+                       },
+                       "duration" : {
+                          "text" : "34 mins",
+                          "value" : 2013
+                       },
+                       "status" : "OK"
+                    },
+                    {
+                       "distance" : {
+                          "text" : "85.4 mi",
+                          "value" : 137513
+                       },
+                       "duration" : {
+                          "text" : "1 hour 50 mins",
+                          "value" : 6608
+                       },
+                       "status" : "OK"
+                    }
+                 ]
+              }
+           ],
+           "status" : "OK"
+        }
+    http_version: 
+  recorded_at: Sat, 20 Jul 2019 22:43:03 GMT
+- request:
+    method: get
+    uri: https://maps.googleapis.com/maps/api/distancematrix/json?destinations=41.0003,-107.0003%7C39.5001,-105.0001%7C40.0002,-106.0002&key=<GOOGLE_DISTANCE_API_KEY>&mode=driving&origins=39.7504,-104.9963&units=imperial
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Sat, 20 Jul 2019 22:43:07 GMT
+      Expires:
+      - Sat, 20 Jul 2019 22:48:07 GMT
+      Cache-Control:
+      - public, max-age=300
+      Vary:
+      - Accept-Language
+      Server:
+      - mafe
+      Content-Length:
+      - '336'
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      Server-Timing:
+      - gfet4t7; dur=60
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="46,43,39"
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+           "destination_addresses" : [
+              "Clark, CO 80428, USA",
+              "9744 Chatridge Ct, Littleton, CO 80125, USA",
+              "Grand Lake, CO 80447, USA"
+           ],
+           "origin_addresses" : [ "1777 Larimer St, Denver, CO 80202, USA" ],
+           "rows" : [
+              {
+                 "elements" : [
+                    {
+                       "distance" : {
+                          "text" : "202 mi",
+                          "value" : 325497
+                       },
+                       "duration" : {
+                          "text" : "4 hours 17 mins",
+                          "value" : 15439
+                       },
+                       "status" : "OK"
+                    },
+                    {
+                       "distance" : {
+                          "text" : "19.9 mi",
+                          "value" : 32029
+                       },
+                       "duration" : {
+                          "text" : "34 mins",
+                          "value" : 2013
+                       },
+                       "status" : "OK"
+                    },
+                    {
+                       "distance" : {
+                          "text" : "85.4 mi",
+                          "value" : 137513
+                       },
+                       "duration" : {
+                          "text" : "1 hour 50 mins",
+                          "value" : 6608
+                       },
+                       "status" : "OK"
+                    }
+                 ]
+              }
+           ],
+           "status" : "OK"
+        }
+    http_version: 
+  recorded_at: Sat, 20 Jul 2019 22:43:03 GMT
+- request:
+    method: get
+    uri: https://maps.googleapis.com/maps/api/distancematrix/json?destinations=41.0003,-107.0003%7C39.5001,-105.0001%7C40.0002,-106.0002&key=<GOOGLE_DISTANCE_API_KEY>&mode=driving&origins=39.7504,-104.9963&units=imperial
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Sat, 20 Jul 2019 22:43:07 GMT
+      Expires:
+      - Sat, 20 Jul 2019 22:48:07 GMT
+      Cache-Control:
+      - public, max-age=300
+      Vary:
+      - Accept-Language
+      Server:
+      - mafe
+      Content-Length:
+      - '336'
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      Server-Timing:
+      - gfet4t7; dur=49
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="46,43,39"
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+           "destination_addresses" : [
+              "Clark, CO 80428, USA",
+              "9744 Chatridge Ct, Littleton, CO 80125, USA",
+              "Grand Lake, CO 80447, USA"
+           ],
+           "origin_addresses" : [ "1777 Larimer St, Denver, CO 80202, USA" ],
+           "rows" : [
+              {
+                 "elements" : [
+                    {
+                       "distance" : {
+                          "text" : "202 mi",
+                          "value" : 325497
+                       },
+                       "duration" : {
+                          "text" : "4 hours 17 mins",
+                          "value" : 15439
+                       },
+                       "status" : "OK"
+                    },
+                    {
+                       "distance" : {
+                          "text" : "19.9 mi",
+                          "value" : 32029
+                       },
+                       "duration" : {
+                          "text" : "34 mins",
+                          "value" : 2013
+                       },
+                       "status" : "OK"
+                    },
+                    {
+                       "distance" : {
+                          "text" : "85.4 mi",
+                          "value" : 137513
+                       },
+                       "duration" : {
+                          "text" : "1 hour 50 mins",
+                          "value" : 6608
+                       },
+                       "status" : "OK"
+                    }
+                 ]
+              }
+           ],
+           "status" : "OK"
+        }
+    http_version: 
+  recorded_at: Sat, 20 Jul 2019 22:43:03 GMT
+- request:
+    method: get
+    uri: https://maps.googleapis.com/maps/api/distancematrix/json?destinations=41.0003,-107.0003%7C39.5001,-105.0001%7C40.0002,-106.0002&key=<GOOGLE_DISTANCE_API_KEY>&mode=driving&origins=39.7504,-104.9963&units=imperial
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Sat, 20 Jul 2019 22:43:07 GMT
+      Expires:
+      - Sat, 20 Jul 2019 22:48:07 GMT
+      Cache-Control:
+      - public, max-age=300
+      Vary:
+      - Accept-Language
+      Server:
+      - mafe
+      Content-Length:
+      - '336'
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      Server-Timing:
+      - gfet4t7; dur=33
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="46,43,39"
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+           "destination_addresses" : [
+              "Clark, CO 80428, USA",
+              "9744 Chatridge Ct, Littleton, CO 80125, USA",
+              "Grand Lake, CO 80447, USA"
+           ],
+           "origin_addresses" : [ "1777 Larimer St, Denver, CO 80202, USA" ],
+           "rows" : [
+              {
+                 "elements" : [
+                    {
+                       "distance" : {
+                          "text" : "202 mi",
+                          "value" : 325497
+                       },
+                       "duration" : {
+                          "text" : "4 hours 17 mins",
+                          "value" : 15439
+                       },
+                       "status" : "OK"
+                    },
+                    {
+                       "distance" : {
+                          "text" : "19.9 mi",
+                          "value" : 32029
+                       },
+                       "duration" : {
+                          "text" : "34 mins",
+                          "value" : 2013
+                       },
+                       "status" : "OK"
+                    },
+                    {
+                       "distance" : {
+                          "text" : "85.4 mi",
+                          "value" : 137513
+                       },
+                       "duration" : {
+                          "text" : "1 hour 50 mins",
+                          "value" : 6608
+                       },
+                       "status" : "OK"
+                    }
+                 ]
+              }
+           ],
+           "status" : "OK"
+        }
+    http_version: 
+  recorded_at: Sat, 20 Jul 2019 22:43:03 GMT
+- request:
+    method: get
+    uri: https://maps.googleapis.com/maps/api/distancematrix/json?destinations=41.0003,-107.0003%7C39.5001,-105.0001%7C40.0002,-106.0002&key=<GOOGLE_DISTANCE_API_KEY>&mode=driving&origins=39.7504,-104.9963&units=imperial
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Sat, 20 Jul 2019 22:43:08 GMT
+      Expires:
+      - Sat, 20 Jul 2019 22:48:08 GMT
+      Cache-Control:
+      - public, max-age=300
+      Vary:
+      - Accept-Language
+      Server:
+      - mafe
+      Content-Length:
+      - '336'
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      Server-Timing:
+      - gfet4t7; dur=75
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="46,43,39"
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+           "destination_addresses" : [
+              "Clark, CO 80428, USA",
+              "9744 Chatridge Ct, Littleton, CO 80125, USA",
+              "Grand Lake, CO 80447, USA"
+           ],
+           "origin_addresses" : [ "1777 Larimer St, Denver, CO 80202, USA" ],
+           "rows" : [
+              {
+                 "elements" : [
+                    {
+                       "distance" : {
+                          "text" : "202 mi",
+                          "value" : 325497
+                       },
+                       "duration" : {
+                          "text" : "4 hours 17 mins",
+                          "value" : 15439
+                       },
+                       "status" : "OK"
+                    },
+                    {
+                       "distance" : {
+                          "text" : "19.9 mi",
+                          "value" : 32029
+                       },
+                       "duration" : {
+                          "text" : "34 mins",
+                          "value" : 2013
+                       },
+                       "status" : "OK"
+                    },
+                    {
+                       "distance" : {
+                          "text" : "85.4 mi",
+                          "value" : 137513
+                       },
+                       "duration" : {
+                          "text" : "1 hour 50 mins",
+                          "value" : 6608
+                       },
+                       "status" : "OK"
+                    }
+                 ]
+              }
+           ],
+           "status" : "OK"
+        }
+    http_version: 
+  recorded_at: Sat, 20 Jul 2019 22:43:03 GMT
+- request:
+    method: get
+    uri: https://maps.googleapis.com/maps/api/distancematrix/json?destinations=41.0003,-107.0003%7C39.5001,-105.0001%7C40.0002,-106.0002&key=<GOOGLE_DISTANCE_API_KEY>&mode=driving&origins=39.7504,-104.9963&units=imperial
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Sat, 20 Jul 2019 22:43:08 GMT
+      Expires:
+      - Sat, 20 Jul 2019 22:48:08 GMT
+      Cache-Control:
+      - public, max-age=300
+      Vary:
+      - Accept-Language
+      Server:
+      - mafe
+      Content-Length:
+      - '336'
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      Server-Timing:
+      - gfet4t7; dur=49
+      Alt-Svc:
+      - quic=":443"; ma=2592000; v="46,43,39"
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+           "destination_addresses" : [
+              "Clark, CO 80428, USA",
+              "9744 Chatridge Ct, Littleton, CO 80125, USA",
+              "Grand Lake, CO 80447, USA"
+           ],
+           "origin_addresses" : [ "1777 Larimer St, Denver, CO 80202, USA" ],
+           "rows" : [
+              {
+                 "elements" : [
+                    {
+                       "distance" : {
+                          "text" : "202 mi",
+                          "value" : 325497
+                       },
+                       "duration" : {
+                          "text" : "4 hours 17 mins",
+                          "value" : 15439
+                       },
+                       "status" : "OK"
+                    },
+                    {
+                       "distance" : {
+                          "text" : "19.9 mi",
+                          "value" : 32029
+                       },
+                       "duration" : {
+                          "text" : "34 mins",
+                          "value" : 2013
+                       },
+                       "status" : "OK"
+                    },
+                    {
+                       "distance" : {
+                          "text" : "85.4 mi",
+                          "value" : 137513
+                       },
+                       "duration" : {
+                          "text" : "1 hour 50 mins",
+                          "value" : 6608
+                       },
+                       "status" : "OK"
+                    }
+                 ]
+              }
+           ],
+           "status" : "OK"
+        }
+    http_version: 
+  recorded_at: Sat, 20 Jul 2019 22:43:03 GMT
+recorded_with: VCR 4.0.0


### PR DESCRIPTION
- [ ] Check this if the PR has been approved by the team to be a quick patch and the rest of this form will not be filled out

## What functionality does this accomplish?
closes #31

**Description:**
This PR backfills testing for the existing `LocationsFacade`.
VCR cassettes to test the `#sorted` and `#combined_data` instance methods. 
Mostly for getting our test coverage up... and also mostly for @mikedao, who likes testing Facades.

* The `GoogleDistanceService` spec was slightly altered, to include a `context` block referencing the `#get_json` 

## What did you struggle on to complete?
Nothing on this one.

## Current Test Suite:
### Test Coverage Percentage: 100%
- [x] Tests have been added
- [ ] No Tests have been changed
- [ ] Some Tests have been changed
- [ ] All of the Tests have been changed(Please describe what in the world happened):

## Checklist:
- [x] My code has no unused/commented out code
- [x] I have reviewed my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have fully tested my code
- [ ] I have partially tested my code (please explain why):

## Helpful Resources:
* Resource link AND small description of info gathered/learned

## Review Requests(optional):
@SallyHaefling 
@BrennanDuffey 

## Co-Authors (optional):

## Please include an emoji of how you feel about this branch:
🤓